### PR TITLE
Redirect fix

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [18.x, 20.x]
+        node-version: [18.x, 20.x, 22.x]
 
     defaults:
       run:

--- a/client/src/context/AuthContext.tsx
+++ b/client/src/context/AuthContext.tsx
@@ -3,10 +3,11 @@ import { authKey } from "../lib/data";
 
 interface AuthContextValue {
   isAuthenticated: boolean;
+  setIsAuthenticated: (value: boolean) => void;
   loading: boolean;
 }
 
-const AuthContext = createContext<AuthContextValue | null>(null);
+const AuthContext = createContext<AuthContextValue | undefined>(undefined);
 
 export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   const [isAuthenticated, setIsAuthenticated] = useState(false);
@@ -18,7 +19,7 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
     setLoading(false);
   }, []);
 
-  return <AuthContext.Provider value={{ isAuthenticated, loading }}>{children}</AuthContext.Provider>;
+  return <AuthContext.Provider value={{ isAuthenticated, setIsAuthenticated, loading }}>{children}</AuthContext.Provider>;
 };
 
 export const useAuth = () => {

--- a/client/src/context/ItemsContext.tsx
+++ b/client/src/context/ItemsContext.tsx
@@ -1,6 +1,7 @@
 import { ReactNode, useState, createContext, useEffect } from "react";
 import { useAuth } from "./AuthContext";
-import { apiUrl, NeededBy, readToken, ShoppingItemWithUser } from "../lib/data";
+import { apiUrl, NeededBy, ShoppingItemWithUser } from "../lib/data";
+import { useUser } from "./useUser";
 
 export type ItemsContextValues = {
   items: ShoppingItemWithUser[] | undefined;
@@ -27,13 +28,9 @@ type Props = {
 export function ItemsProvider({ children }: Props) {
   const [items, setItems] = useState<ShoppingItemWithUser[]>([]);
   const [neededBy, setNeededBy] = useState<NeededBy[]>([]);
-  const [token, setToken] = useState<string>();
+  const { token } = useUser();
   const { isAuthenticated } = useAuth();
   const [error, setError] = useState<unknown>();
-
-  useEffect(() => {
-    setToken(readToken());
-  });
 
   useEffect(() => {
     if (isAuthenticated) {

--- a/client/src/context/UserContext.tsx
+++ b/client/src/context/UserContext.tsx
@@ -6,6 +6,7 @@ export type UserContextValues = {
   user: User | undefined;
   users: User[] | undefined;
   token: string | undefined;
+  setToken: (token: string) => void;
   shopper: Shopper | undefined;
   handleSignIn: (user: User, token: string) => void;
   handleSignOut: () => void;
@@ -16,6 +17,7 @@ export const UserContext = createContext<UserContextValues>({
   user: undefined,
   users: undefined,
   token: undefined,
+  setToken: () => undefined,
   shopper: undefined,
   handleSignIn: () => undefined,
   handleSignOut: () => undefined,
@@ -114,6 +116,6 @@ export function UserProvider({ children }: Props) {
     return <div>Error! {error instanceof Error ? error.message : "Unknown error"}</div>;
   }
 
-  const contextValue = { user, users, token, shopper, handleSignIn, handleSignOut, fetchShopper };
+  const contextValue = { user, users, token, setToken, shopper, handleSignIn, handleSignOut, fetchShopper };
   return <UserContext.Provider value={contextValue}>{children}</UserContext.Provider>;
 }

--- a/client/src/pages/protected-routes.tsx
+++ b/client/src/pages/protected-routes.tsx
@@ -1,11 +1,17 @@
-import { Navigate, Outlet } from "react-router-dom";
+import { Navigate, Outlet, useNavigate } from "react-router-dom";
 import { useAuth } from "../context/AuthContext";
 import { useEffect } from "react";
 
 export function ProtectedRoutes() {
   const { isAuthenticated, loading } = useAuth();
+  const navigate = useNavigate();
 
-  useEffect(() => {}, [isAuthenticated]); // Checks if isAuthenticated changes after sign-in POST request
+  // Checks if isAuthenticated changes after sign-in POST request
+  useEffect(() => {
+    if (isAuthenticated) {
+      navigate("/");
+    }
+  }, [isAuthenticated]);
 
   if (loading) {
     return <div>Loading...</div>;

--- a/client/src/pages/sign-in.tsx
+++ b/client/src/pages/sign-in.tsx
@@ -10,6 +10,7 @@ import { apiUrl, User } from "../lib/data";
 import { useUser } from "../context/useUser";
 import { Input } from "../components/ui/input";
 import { Button } from "../components/ui/button";
+import { useAuth } from "../context/AuthContext";
 
 const formSchema = z.object({
   username: z.string().min(5, {
@@ -26,8 +27,9 @@ type AuthData = {
 };
 
 export function SignInPage() {
-  const navigate = useNavigate();
   const { handleSignIn } = useUser();
+  const { setIsAuthenticated } = useAuth();
+  const navigate = useNavigate();
 
   const form = useForm<z.infer<typeof formSchema>>({
     resolver: zodResolver(formSchema),
@@ -54,6 +56,7 @@ export function SignInPage() {
       handleSignIn(user, token);
     },
     onSuccess: () => {
+      setIsAuthenticated(true);
       navigate("/");
     },
     onError: (err: Error) => {


### PR DESCRIPTION
Sign-in redirect issue:
I was not using setIsAuthenticated(true) in my mutation function for the sign in form.  isAuthenticated state was not changing which was the reason I was

CORS Errors For 2 GET Requests:
Received 401 CORS errors for the GET requests coming from ItemsContext. For example when fetching shopping items and the needed by users. However, all the rest of the GET requests coming from UserContext were 200 successful. I realized I mistakenly created an entirely separate state for token in ItemsContext. This resulted in me having no bearer token included in all my fetch requests from ItemsContext.

I destructured the token from the UserContext into ItemsContext. Then I successfully was initiating GET requests and no longer getting 401 CORS header missing errors.